### PR TITLE
SIR-298 : Send Minecraft Event Data To Bridge Server 

### DIFF
--- a/bridge_message_format.js
+++ b/bridge_message_format.js
@@ -1,0 +1,25 @@
+export function createBridgeMessage(reason, eventName, data = {}) {
+    const priorities = {
+        chat: 1,
+        health: 3,
+        death: 1,
+        kicked: 2,
+        idle: 4,
+        self_defense: 2,
+        hunting: 2,
+        cowardice: 3
+    };
+
+    if (!priorities[eventName]) {
+        console.warn(`Unknown event name: ${eventName}. Valid events are: ${Object.keys(priorities).join(', ')}`);
+        return null; 
+    }
+
+    return {
+        priority: priorities[eventName],
+        reason,
+        eventName,
+        timestamp: Date.now(),
+        data: data,
+    };
+}

--- a/settings.js
+++ b/settings.js
@@ -3,6 +3,9 @@ const settings = {
     "host": "127.0.0.1", // or "localhost", "your.ip.address.here"
     "port": 55916,
     "auth": "offline", // or "microsoft"
+    //minecraft bridge server URL
+    "minecraft_bridge_server_url": "ws://localhost", 
+    "minecraft_bridge_server_port": 3000, 
 
     // the mindserver manages all agents and hosts the UI
     "host_mindserver": true, // if true, the mindserver will be hosted on this machine. otherwise, specify a public IP address

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -394,10 +394,10 @@ export class Agent {
         this.bot.lastDamageTaken = 0;
         this.bot.on('health', () => {
             const healthChange = prev_health - this.bot.health;
-            const MAJOR_HEALTH_DECREASE = 20; // Define what constitutes a major decrease
-            if (healthChange >= MAJOR_HEALTH_DECREASE) {
-            const message = createBridgeMessage('Major health decrease', 'health', {
-                 health: this.bot.health, damageTaken: healthChange 
+            if (healthChange > 0) { 
+            const message = createBridgeMessage('Health decrease', 'health', {
+                health: this.bot.health,
+                damageTaken: healthChange
             });
             this.connectBridgeServer.sendMessage(message);
             }

--- a/src/process/connect_bridge_server.js
+++ b/src/process/connect_bridge_server.js
@@ -1,0 +1,76 @@
+import WebSocket from 'ws';
+import settings from '../../settings.js';
+
+class ConnectBridgeServer {
+    constructor() {
+        if (ConnectBridgeServer.instance) return ConnectBridgeServer.instance;
+
+        this.socket = null;
+        this.connected = false;
+        this.reconnectInterval = 5000;
+        ConnectBridgeServer.instance = this;
+    }
+
+    connect(agent) {
+        if (this.connected) return this.ready;
+
+        const serverUrl = `${settings.minecraft_bridge_server_url}:${settings.minecraft_bridge_server_port}/events`;
+
+        try {
+            this.socket = new WebSocket(serverUrl);
+
+            this.socket.on('open', () => {
+                console.log('WebSocket connected to bridge server.');
+                this.connected = true;
+            });
+
+            this.socket.on('close', () => {
+                console.log('WebSocket connection closed to bridge server.');
+                this.connected = false;
+            });
+
+            this.socket.on('error', (error) => {
+                console.error(`Websocket Bridge Connection error: ${error.message}`);
+                this.connected = false;
+                this.scheduleReconnect();
+            });
+
+            this.socket.on('message', (message) => {
+                console.log('Received message:', message);
+                try {
+                    const parsedMessage = JSON.parse(message);
+                    const { source, content } = parsedMessage;
+                    if (source && content) {
+                        agent.handleMessage(source, content);
+                    } else {
+                        console.warn('Invalid message format received:', message);
+                    }
+                } catch (error) {
+                    console.error('Error processing received message:', error);
+                }
+            });
+
+        } catch (error) {
+            console.error(`Failed to initialize WebSocket: ${error.message}`);
+            this.scheduleReconnect();
+        }
+    }
+
+    scheduleReconnect() {
+        if (!this.connected) {
+            console.log('Attempting to reconnect...');
+            setTimeout(() => this.connect(), this.reconnectInterval);
+        }
+    }
+
+    sendMessage(message) {
+        if (this.socket?.readyState === WebSocket.OPEN) {
+            this.socket.send(JSON.stringify(message));
+            console.log('Message sent to bridge server:', message);
+        } else {
+            console.warn('Bridge server not connected or not ready. Message not sent:', message);
+        }
+    }
+}
+
+export const connectBridgeServer = new ConnectBridgeServer();

--- a/src/process/init_agent.js
+++ b/src/process/init_agent.js
@@ -1,4 +1,5 @@
 import { Agent } from '../agent/agent.js';
+import { connectBridgeServer } from './connect_bridge_server.js';
 import yargs from 'yargs';
 
 // Add global unhandled rejection handler
@@ -55,7 +56,8 @@ const argv = yargs(args)
     try {
         console.log('Starting agent with profile:', argv.profile);
         const agent = new Agent();
-        await agent.start(argv.profile, argv.load_memory, argv.init_message, argv.count_id, argv.task_path, argv.task_id);
+        await connectBridgeServer.connect(agent);
+        await agent.start(argv.profile, argv.load_memory, argv.init_message, argv.count_id, argv.task_path, argv.task_id, connectBridgeServer);
     } catch (error) {
         console.error('Failed to start agent process:');
         console.error(error.message);


### PR DESCRIPTION
### Linear Ticket
- [SIR-298: Plan to Integrate Ima-MC v0.1](https://linear.app/siremo/issue/SIR-298/plan-to-integrate-ima-mc-v01)

###  Architecture
- [Ima-chan Minecraft Integration Architecture](https://www.notion.so/Ima-chan-Minecraft-Integration-Architecture-21815a31722480a5a8c5c630122734b6)

---

### Changes

- Created a `connectBridgeServer` script to send and receive messages from the Bridge Server.
- Defined a `bridgeMessageFormat` to describe the priorities of various events and the message structure used on the Bridge Server side.
- Integrated logic to send major events to the Bridge Server.